### PR TITLE
Add option to continue streaming on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ module.exports.register = function (Handlebars) {
 };
 ```
 
+### `continueOnError` `{Boolean}` (default: `false`)
+
+Whether to continue streaming when an error occurs and emitting a `failure` event. See https://github.com/dominictarr/map-stream#options
+
 ## Contribute
 
 [![Tasks][waffle-img]][waffle-url] [![Tip][gittip-img]][gittip-url]

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var hb = require('handlebars'),
  * @param {Object|String|Array.<String>|Function} options.helpers One or more glob strings matching helpers.
  * @param {Object|String|Array.<String>|Function} options.partials One or more glob strings matching partials.
  * @param {Boolean} options.file Whether to include the file object in the data passed to the template.
+ * @param {Boolean} options.continueOnError Whether to continue streaming when an error occurs and emitting a "failure" event.
  * @return {Stream}
  */
 module.exports = function (options) {
@@ -60,5 +61,7 @@ module.exports = function (options) {
 		file.contents = new Buffer(template(context));
 
 		cb(null, file);
+	}, {
+		failures: options.continueOnError
 	});
 };


### PR DESCRIPTION
Currently, the stream ends when an error occurs. This is undesirable when having a watch process running, e.g.

A solution is to use the `failures` option of `map-stream` which was added for this case: https://github.com/dominictarr/map-stream/pull/7

What do you think?