### PR TITLE
Allow file-specific data in options.data

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ gulp.task('i18n', function () {
   - `parseHelperName` `{Function(options, file): String}`
   - `decorators` `{String|Array.<String>|Object|Function(handlebars)}`
   - `parseDecoratorName` `{Function(options, file): String}`
-  - `data` `{String|Array.<String>|Object}`
+  - `data` `{String|Array.<String>|Object|Function(file)}`
   - `parseDataName` `{Function(options, file): String}`
 
 Returns a Gulp-compatible transform stream that compiles [Handlebars][handlebars] templates to static output.

--- a/src/gulp-hb.js
+++ b/src/gulp-hb.js
@@ -60,7 +60,7 @@ function gulpHb(options) {
 		wax.decorators(options.decorators);
 	}
 
-	if (options.data) {
+	if (options.data && typeof options.data !== 'function') {
 		wax.data(options.data);
 	}
 
@@ -80,6 +80,10 @@ function gulpHb(options) {
 		try {
 			var data = assign({}, file.data);
 			var template = wax.compile(file.contents.toString());
+
+			if (options.data && typeof options.data === 'function') {
+				wax.data(options.data(file));
+			}
 
 			if (debug) {
 				logKeys(file, [

--- a/test/gulp-hb.js
+++ b/test/gulp-hb.js
@@ -123,6 +123,38 @@ test.cb('should use registered data', t => {
 	}));
 });
 
+test.cb('should use file-specific registered data', t => {
+	const stream = gulpHb({
+		data: function (file) {
+			return {
+				foo: file.path
+			};
+		}
+	});
+
+	stream.data({
+		bar: 'barA'
+	});
+
+	stream.on('data', file => {
+		t.is(file.contents.toString(), file.path + ' ' + file.path + ' barA');
+	});
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: path.join(__dirname, 'fixture', 'fixture.js'),
+		contents: new Buffer('{{@root.foo}} {{foo}} {{bar}}')
+	}));
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: path.join(__dirname, 'fixture', 'fixture2.js'),
+		contents: new Buffer('{{@root.foo}} {{foo}} {{bar}}')
+	}));
+
+	setImmediate(t.end);
+});
+
 test.cb('should use registered partial', t => {
 	const stream = gulpHb({
 		partials: {


### PR DESCRIPTION
Previously, `dataEach` allowed us to define file-specific `@root` data. Allowing a function for `options.data` would restore this functionality.

See https://github.com/shannonmoeller/gulp-hb/issues/10#issuecomment-275220220

/cc @swey