### PR TITLE
Fix test on Windows

### DIFF
--- a/test/gulp-hb.js
+++ b/test/gulp-hb.js
@@ -68,7 +68,7 @@ test.cb('should render a template with file', t => {
 	const stream = gulpHb();
 
 	stream.on('data', file => {
-		t.is(file.contents.toString(), 'hello fixture/fixture.html');
+		t.is(file.contents.toString(), 'hello fixture' + path.sep + 'fixture.html');
 		t.end();
 	});
 


### PR DESCRIPTION
This fixes a test that failed due to the path seperator being different on Windows.